### PR TITLE
feat: add configurable provider timeout options

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,10 @@
 page_title: "clickhouse Provider"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # clickhouse Provider
-
-
 
 ## Example Usage
 
@@ -28,6 +26,11 @@ provider "clickhouse" {
   host     = "127.0.0.1"
   username = "default"
   password = ""
+
+  # Optional: Timeout and retry settings for idle/sleeping services
+  dial_timeout = 60
+  max_retries  = 5
+  retry_delay  = 10
 }
 ```
 
@@ -37,8 +40,12 @@ provider "clickhouse" {
 ### Optional
 
 - `default_cluster` (String) Default cluster, if provided will be used when no cluster is provided
+- `dial_timeout` (Number) Timeout for establishing a connection to ClickHouse (in seconds). Useful for services that may need time to wake up. Defaults to `30`.
 - `host` (String) Clickhouse server URL
+- `max_retries` (Number) Maximum number of retry attempts when connecting to ClickHouse. Set to 0 to disable retries. Defaults to `0`.
 - `password` (String, Sensitive) Clickhouse user password with admin privileges
 - `port` (Number) Clickhouse server native protocol port (TCP)
+- `read_timeout` (Number) Timeout for reading data from ClickHouse (in seconds). Defaults to `300`.
+- `retry_delay` (Number) Initial delay between retry attempts (in seconds). The delay increases exponentially with each retry. Defaults to `5`.
 - `secure` (Boolean) Clickhouse secure connection
 - `username` (String) Clickhouse username with admin privileges

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -13,4 +13,9 @@ provider "clickhouse" {
   host     = "127.0.0.1"
   username = "default"
   password = ""
+
+  # Optional: Timeout and retry settings for idle/sleeping services
+  dial_timeout = 60
+  max_retries  = 5
+  retry_delay  = 10
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/FlowdeskMarkets/terraform-provider-clickhouse/pkg/common"
 	"github.com/FlowdeskMarkets/terraform-provider-clickhouse/pkg/datasources"
 	"github.com/FlowdeskMarkets/terraform-provider-clickhouse/pkg/resources"
 	"github.com/FlowdeskMarkets/terraform-provider-clickhouse/pkg/sdk"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+const minRetryDelay = 100 * time.Millisecond
 
 func init() {
 	// Set descriptions to support markdown syntax, this will be used in document generation
@@ -28,6 +33,29 @@ func init() {
 	// 	}
 	// 	return strings.TrimSpace(desc)
 	// }
+}
+
+func validateNonNegative(field string) schema.SchemaValidateDiagFunc {
+	return func(i any, path cty.Path) diag.Diagnostics {
+		value, ok := i.(int)
+		if !ok {
+			return diag.Diagnostics{diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       fmt.Sprintf("%s must be an integer", field),
+				AttributePath: path,
+			}}
+		}
+
+		if value < 0 {
+			return diag.Diagnostics{diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       fmt.Sprintf("%s must be greater than or equal to 0", field),
+				AttributePath: path,
+			}}
+		}
+
+		return nil
+	}
 }
 
 func New(version string) func() *schema.Provider {
@@ -70,6 +98,34 @@ func New(version string) func() *schema.Provider {
 					Optional:    true,
 					Default:     false,
 				},
+				"dial_timeout": {
+					Description:      "Timeout for establishing a connection to ClickHouse (in seconds). Useful for services that may need time to wake up.",
+					Type:             schema.TypeInt,
+					Optional:         true,
+					Default:          30,
+					ValidateDiagFunc: validateNonNegative("dial_timeout"),
+				},
+				"read_timeout": {
+					Description:      "Timeout for reading data from ClickHouse (in seconds).",
+					Type:             schema.TypeInt,
+					Optional:         true,
+					Default:          300,
+					ValidateDiagFunc: validateNonNegative("read_timeout"),
+				},
+				"max_retries": {
+					Description:      "Maximum number of retry attempts when connecting to ClickHouse. Set to 0 to disable retries.",
+					Type:             schema.TypeInt,
+					Optional:         true,
+					Default:          0,
+					ValidateDiagFunc: validateNonNegative("max_retries"),
+				},
+				"retry_delay": {
+					Description:      "Initial delay between retry attempts (in seconds). The delay increases exponentially with each retry.",
+					Type:             schema.TypeInt,
+					Optional:         true,
+					Default:          5,
+					ValidateDiagFunc: validateNonNegative("retry_delay"),
+				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"clickhouse_dbs": datasources.DataSourceDbs(),
@@ -93,6 +149,10 @@ func configure() func(context.Context, *schema.ResourceData) (any, diag.Diagnost
 		username := d.Get("username").(string)
 		password := d.Get("password").(string)
 		secure := d.Get("secure").(bool)
+		dialTimeout := time.Duration(d.Get("dial_timeout").(int)) * time.Second
+		readTimeout := time.Duration(d.Get("read_timeout").(int)) * time.Second
+		maxRetries := d.Get("max_retries").(int)
+		retryDelay := time.Duration(d.Get("retry_delay").(int)) * time.Second
 
 		var TLSConfig *tls.Config
 		// To use TLS it's necessary to set the TLSConfig field as not nil
@@ -116,7 +176,9 @@ func configure() func(context.Context, *schema.ResourceData) (any, diag.Diagnost
 			Settings: clickhouse.Settings{
 				"max_execution_time": 300,
 			},
-			TLS: TLSConfig,
+			DialTimeout: dialTimeout,
+			ReadTimeout: readTimeout,
+			TLS:         TLSConfig,
 		})
 
 		var diags diag.Diagnostics
@@ -125,10 +187,48 @@ func configure() func(context.Context, *schema.ResourceData) (any, diag.Diagnost
 			return nil, diag.FromErr(fmt.Errorf("error connecting to clickhouse: %v", err))
 		}
 
-		if err := conn.Ping(ctx); err != nil {
+		if err := pingWithRetry(ctx, conn, maxRetries, retryDelay); err != nil {
 			return nil, diag.FromErr(fmt.Errorf("ping clickhouse database: %w", err))
 		}
 
 		return &sdk.Client{Conn: conn}, diags
 	}
+}
+
+type pinger interface {
+	Ping(context.Context) error
+}
+
+// pingWithRetry attempts to ping the ClickHouse connection with exponential backoff retry logic.
+// This is useful for services that may take time to wake up from an idle state.
+func pingWithRetry(ctx context.Context, conn pinger, maxRetries int, retryDelay time.Duration) error {
+	var lastErr error
+	delay := max(retryDelay, minRetryDelay)
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if err := conn.Ping(ctx); err != nil {
+			lastErr = err
+			if attempt < maxRetries {
+				jitter := time.Duration(rand.Int63n(int64(delay/2))) - delay/4
+				sleep := delay + jitter
+
+				timer := time.NewTimer(sleep)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return fmt.Errorf("context cancelled while retrying: %w", ctx.Err())
+				case <-timer.C:
+				}
+
+				delay *= 2
+			}
+		} else {
+			return nil
+		}
+	}
+
+	if maxRetries > 0 {
+		return fmt.Errorf("failed after %d retries: %w", maxRetries, lastErr)
+	}
+	return lastErr
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -19,5 +21,71 @@ var ProviderFactories = map[string]func() (*schema.Provider, error){
 func TestProvider(t *testing.T) {
 	if err := New("dev")().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+// mockPinger is a mock implementation of the pinger interface for testing
+type mockPinger struct {
+	pingFunc func(context.Context) error
+}
+
+func (m *mockPinger) Ping(ctx context.Context) error {
+	return m.pingFunc(ctx)
+}
+
+func TestPingWithRetry_ImmediateSuccess(t *testing.T) {
+	mock := &mockPinger{
+		pingFunc: func(ctx context.Context) error {
+			return nil
+		},
+	}
+
+	err := pingWithRetry(context.Background(), mock, 3, minRetryDelay)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestPingWithRetry_SuccessAfterRetries(t *testing.T) {
+	attempts := 0
+	mock := &mockPinger{
+		pingFunc: func(ctx context.Context) error {
+			attempts++
+			if attempts < 3 {
+				return errors.New("connection refused")
+			}
+			return nil
+		},
+	}
+
+	err := pingWithRetry(context.Background(), mock, 5, minRetryDelay)
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts, got: %d", attempts)
+	}
+}
+
+func TestPingWithRetry_FailureAfterMaxRetries(t *testing.T) {
+	attempts := 0
+	expectedErr := errors.New("i/o timeout")
+	mock := &mockPinger{
+		pingFunc: func(ctx context.Context) error {
+			attempts++
+			return expectedErr
+		},
+	}
+
+	err := pingWithRetry(context.Background(), mock, 2, minRetryDelay)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	// Should attempt initial + 2 retries = 3 total
+	if attempts != 3 {
+		t.Fatalf("expected 3 attempts (initial + 2 retries), got: %d", attempts)
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected wrapped timeout error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Overview

This PR introduces new backwards-compatible provider timeout configurations:

  | Option       | Type | Default | Description                             |
  |--------------|------|---------|-----------------------------------------|
  | dial_timeout | int  | 30      | Connection timeout (seconds)            |
  | read_timeout | int  | 300     | Read timeout (seconds)                  |
  | max_retries  | int  | 0       | Number of retry attempts (0 = disabled) |
  | retry_delay  | int  | 5       | Initial delay between retries (seconds) |

### Changes made

  1. Added timeout options - DialTimeout and ReadTimeout are now passed to the clickhouse-go driver
  2. Added retry logic - New pingWithRetry() function with exponential backoff
  3. Backward compatible - Default values match previous behavior (no retries by default)

### Usage example

```hcl
  provider "clickhouse" {
    host         = "clickhouse-host.com"
    port         = 9440
    username     = "default"
    password     = "secret"
    secure       = true

    # Dial timeout/retry for idle services
    dial_timeout = 90      # Wait up to 90s for connection
    max_retries  = 5       # Retry up to 5 times
    retry_delay  = 10      # Start with 10s delay (doubles each retry)

    # Read timeout for long-running tasks
     read_timeout = 400
  }
```

With these settings, the provider will wait up to 90 seconds for the initial connection, then retry the ping up to 5 times with delays of 10s, 20s, 40s, 80s, and 160s before giving up.

## Context

Closes #35 