### PR TITLE
fix: wrap table comments with getComment()

### DIFF
--- a/pkg/sdk/tables_columns.go
+++ b/pkg/sdk/tables_columns.go
@@ -91,7 +91,7 @@ func UpdateColumns(ctx context.Context, c *Client, table models.TableResource, c
 		{
 			condition: !exists,
 			query:     "ALTER TABLE %s.%s %s ADD COLUMN %s %s %s %s %s %s %s",
-			args:      generateArgs(columnMap["type"], columnMap["default_kind"], columnMap["default_expression"], columnMap["compression_codec"], columnMap["comment"].(string), columnMap["location"]),
+			args:      generateArgs(columnMap["type"], columnMap["default_kind"], columnMap["default_expression"], columnMap["compression_codec"], getComment(columnMap["comment"].(string)), columnMap["location"]),
 		},
 		{
 			condition: exists && columnDiffers(oldColumnMap, columnMap, "type"),


### PR DESCRIPTION
## Purpose

This fixes a bug when adding a new column with a comment, the comment was being inserted as a raw string without the COMMENT keyword prefix. 

We now use  the existing `getComment()` function  properly wraps the comment or return an empty string when there's no comment.

## Context

Closes #34 

